### PR TITLE
Fix T1138 to properly detect Application Shimming Installation

### DIFF
--- a/BLUESPAWN/Hunt/Hunts/src/HuntT1138.cpp
+++ b/BLUESPAWN/Hunt/Hunts/src/HuntT1138.cpp
@@ -19,8 +19,8 @@ namespace Hunts {
 
 		int identified = 0;
 
-		identified += CheckKey({ HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags", L"InstalledSDB" }, L"", reaction);
-		identified += CheckKey({ HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags", L"Custom" }, L"", reaction);
+		identified += CheckForSubkeys({ HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB"}, reaction);
+		identified += CheckForSubkeys({ HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Custom"}, reaction);
 		
 		return identified;
 	}


### PR DESCRIPTION
Tested and verified that this will catch T1138 now by using the
Atomic Red Team package. This wasn't detecting before.
https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1138/T1138.md