### PR TITLE
Agent debug bugfix

### DIFF
--- a/BLUESPAWN-agent/CommonLib/CommonLib.props
+++ b/BLUESPAWN-agent/CommonLib/CommonLib.props
@@ -6,6 +6,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(SolutionDir)CommonLib\headers\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/BLUESPAWN-agent/Hunt/Configuration/headers/configuration/Registry.h
+++ b/BLUESPAWN-agent/Hunt/Configuration/headers/configuration/Registry.h
@@ -18,8 +18,6 @@ namespace Registry {
 	extern std::map<std::wstring, HKEY> vHiveNames;
 	extern std::map<HKEY, std::wstring> vHives;
 	extern std::map<HKEY, DWORD> _globalOpenKeys;
-	
-	HKEY RemoveHive(std::wstring& path);
 
 	class RegistryKey : public Loggable {
 		HKEY hive;

--- a/BLUESPAWN-agent/Hunt/Configuration/src/Registry.cpp
+++ b/BLUESPAWN-agent/Hunt/Configuration/src/Registry.cpp
@@ -207,7 +207,7 @@ namespace Registry {
 
 		LOG_VERBOSE(1, dwValueCount << " subkeys detected under " << vHives[hive] << "\\" << path);
 
-		std::vector<RegistryKey> vSubKeys{};
+		auto vSubKeys = std::vector<RegistryKey>();
 
 		if(status == ERROR_SUCCESS && dwValueCount) {
 			for(unsigned i = 0; i < dwValueCount; i++) {
@@ -216,12 +216,13 @@ namespace Registry {
 				status = RegEnumValueW(key, i, lpwName, &length, nullptr, nullptr, nullptr, nullptr);
 
 				if(status == ERROR_SUCCESS) {
-					vSubKeys.push_back({ hive, path, lpwName });
+					vSubKeys.push_back(RegistryKey{ hive, path, std::wstring{lpwName} });
 				} else {
 					LOG_WARNING("Error " << status << " when enumerating the next value!");
 				}
 			}
 		}
+
 		return vSubKeys;
 	}
 

--- a/BLUESPAWN-agent/Logging/Logging.vcxproj
+++ b/BLUESPAWN-agent/Logging/Logging.vcxproj
@@ -437,6 +437,8 @@
       <AdditionalIncludeDirectories>$(ProjectDir)\grpc\include;$(ProjectDir)\grpc\generated;$(SolutionDir)\Hunt\Configuration\headers;%(AdditionalIncludeDirectories) (edited) </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_WIN32_WINNT=0x600;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>-DNOMINMAX %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>
+      </DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/BLUESPAWN-agent/Logging/headers/logging/CLISink.h
+++ b/BLUESPAWN-agent/Logging/headers/logging/CLISink.h
@@ -56,7 +56,8 @@ namespace Log {
 		 * @param level The level at which the message is being logged
 		 * @param message The message to log
 		 */
-		virtual void LogMessage(const LogLevel& level, const std::string& message, const HuntInfo& info = {}, const std::vector<DETECTION*>& detections = {});
+		virtual void LogMessage(const LogLevel& level, const std::string& message, const HuntInfo& info = {}, 
+			                    const std::vector<std::shared_ptr<DETECTION>>& detections = {}) override;
 
 		/**
 		 * Compares this CLISink to another LogSink. Currently, as only one console is supported,

--- a/BLUESPAWN-agent/Logging/headers/logging/DebugSink.h
+++ b/BLUESPAWN-agent/Logging/headers/logging/DebugSink.h
@@ -22,7 +22,8 @@ namespace Log {
 		 * @param level The level at which the message is being logged
 		 * @param message The message to log
 		 */
-		virtual void LogMessage(const LogLevel& level, const std::string& message, const HuntInfo& info = {}, const std::vector<DETECTION*>& detections = {});
+		virtual void LogMessage(const LogLevel& level, const std::string& message, const HuntInfo& info = {}, 
+			const std::vector<std::shared_ptr<DETECTION>>& detections = {});
 
 		/**
 		 * Compares this DebugSink to another LogSink. Currently, as only one debug console is supported,

--- a/BLUESPAWN-agent/Logging/headers/logging/HuntLogMessage.h
+++ b/BLUESPAWN-agent/Logging/headers/logging/HuntLogMessage.h
@@ -8,6 +8,7 @@
 
 #include <vector>
 #include <string>
+#include <memory>
 
 // Creates a Hunt log message named _HuntLogMessage. This macro is only to be called inside
 // ScanCursory, ScanModerate, ScanCareful, or ScanAggressive.
@@ -15,7 +16,7 @@
     auto _HuntLogMessage = Log::HuntLogMessage(GET_INFO(), Log::_LogHuntSinks)
 
 // Logs a detection to the log message for the current hunt. LOG_HUNT_BEGIN should be called first.
-#define LOG_HUNT_DETECTION(detection) _HuntLogMessage.AddDetection(reinterpret_cast<DETECTION*>(detection))
+#define LOG_HUNT_DETECTION(detection) _HuntLogMessage.AddDetection(std::static_pointer_cast<DETECTION>(detection))
 
 // Adds a message to the log for this hunt. LOG_HUNT_BEGIN should be called first.
 #define LOG_HUNT_MESSAGE(...) _HuntLogMessage << __VA_ARGS__
@@ -38,7 +39,7 @@ namespace Log {
 	 */
 	class HuntLogMessage : public LogMessage {
 	protected:
-		std::vector<DETECTION*> Detections;
+		std::vector<std::shared_ptr<DETECTION>> Detections;
 		HuntInfo HuntName;
 
 	public:
@@ -65,7 +66,7 @@ namespace Log {
 		 * @param detection The detection to record. This should be an instance of 
 		 *		  FILE_DETECTION, REGISTRY_DETECTION, SERIVCE_DETECTION, or PROCESS_DETECTION.
 		 */
-		void AddDetection(DETECTION* detection);
+		void AddDetection(std::shared_ptr<DETECTION> detection);
 
 		/**
 		 * When the LogTerminator is supplied to the stream, the stream is terminated and forwarded to

--- a/BLUESPAWN-agent/Logging/headers/logging/LogSink.h
+++ b/BLUESPAWN-agent/Logging/headers/logging/LogSink.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 
 #include "reactions/Reaction.h"
 #include "hunts/Hunt.h"
@@ -28,7 +29,8 @@ namespace Log {
 		 * @param level The level at which to log
 		 * @param message The message to be logged
 		 */
-		virtual void LogMessage(const LogLevel& level, const std::string& message, const HuntInfo& info = {}, const std::vector<DETECTION*> & detections = {}) = 0;
+		virtual void LogMessage(const LogLevel& level, const std::string& message, const HuntInfo& info = {}, 
+			                    const std::vector<std::shared_ptr<DETECTION>>& detections = {}) = 0;
 
 		/**
 		 * This function should be implemented to determine whether two log sinks are equal.

--- a/BLUESPAWN-agent/Logging/headers/logging/ServerSink.h
+++ b/BLUESPAWN-agent/Logging/headers/logging/ServerSink.h
@@ -29,10 +29,10 @@ namespace Log {
 		std::vector<gpb::DataSource> HuntDatasourcesToGPB(const DWORD& info);
 		gpb::HuntInfo HuntInfoToGPB(const HuntInfo& info);
 
-		std::vector<gpb::FileReactionData> GetFileReactions(const std::vector<DETECTION*>& detections);
-		std::vector<gpb::RegistryReactionData> GetRegistryReactions(const std::vector<DETECTION*>& detections);
-		std::vector<gpb::ProcessReactionData> GetProcessReactions(const std::vector<DETECTION*>& detections);
-		std::vector<gpb::ServiceReactionData> GetServiceReactions(const std::vector<DETECTION*>& detections);
+		std::vector<gpb::FileReactionData> GetFileReactions(const std::vector<std::shared_ptr<DETECTION>>& detections);
+		std::vector<gpb::RegistryReactionData> GetRegistryReactions(const std::vector<std::shared_ptr<DETECTION>>& detections);
+		std::vector<gpb::ProcessReactionData> GetProcessReactions(const std::vector<std::shared_ptr<DETECTION>>& detections);
+		std::vector<gpb::ServiceReactionData> GetServiceReactions(const std::vector<std::shared_ptr<DETECTION>>& detections);
 
 	public:
 
@@ -43,7 +43,8 @@ namespace Log {
 		 * @param level The level at which the message is being logged
 		 * @param message The message to log
 		 */
-		virtual void LogMessage(const LogLevel& level, const std::string& message, const HuntInfo& info = {}, const std::vector<DETECTION*>& detections = {});
+		virtual void LogMessage(const LogLevel& level, const std::string& message, const HuntInfo& info = {}, 
+			                    const std::vector<std::shared_ptr<DETECTION>>& detections = {}) override;
 
 		/**
 		 * Compares this ServerSink to another LogSink. Currently, as only one console is supported,

--- a/BLUESPAWN-agent/Logging/src/CLISink.cpp
+++ b/BLUESPAWN-agent/Logging/src/CLISink.cpp
@@ -11,7 +11,7 @@ namespace Log {
 		SetConsoleTextAttribute(hConsole, static_cast<WORD>(color));
 	}
 
-	void CLISink::LogMessage(const LogLevel& level, const std::string& message, const HuntInfo& info, const std::vector<DETECTION*>& detections){
+	void CLISink::LogMessage(const LogLevel& level, const std::string& message, const HuntInfo& info, const std::vector<std::shared_ptr<DETECTION>>& detections){
 		if(level.Enabled()){
 			SetConsoleColor(CLISink::PrependColors[static_cast<WORD>(level.severity)]);
 
@@ -23,17 +23,17 @@ namespace Log {
 				SetConsoleColor(CLISink::MessageColor::LIGHTGREY);
 				std::wcout << L" - " << detections.size() << " detection" << (detections.size() == 1 ? L"" : L"s") << L"!" << std::endl;
 				for(auto detection : detections){
-					if(detection->DetectionType == DetectionType::File){
-						auto* lpFileDetection = reinterpret_cast<FILE_DETECTION*>(detection); 
+					if(detection->Type == DetectionType::File){
+						auto lpFileDetection = std::static_pointer_cast<FILE_DETECTION>(detection); 
 						std::wcout << L"\tPotentially malicious file detected - " << lpFileDetection->wsFileName << L" (hash is " << lpFileDetection->hash << L")" << std::endl;
-					} else if(detection->DetectionType == DetectionType::Process){
-						auto* lpProcessDetection = reinterpret_cast<PROCESS_DETECTION*>(detection);
+					} else if(detection->Type == DetectionType::Process){
+						auto lpProcessDetection = std::static_pointer_cast<PROCESS_DETECTION>(detection);
 						std::wcout << L"\tPotentially malicious process detected - " << lpProcessDetection->wsImageName << L" (PID is " << lpProcessDetection->PID << L")" << std::endl;
-					} else if(detection->DetectionType == DetectionType::Service){
-						auto* lpServiceDetection = reinterpret_cast<SERVICE_DETECTION*>(detection);
+					} else if(detection->Type == DetectionType::Service){
+						auto lpServiceDetection = std::static_pointer_cast<SERVICE_DETECTION>(detection);
 						std::wcout << L"\tPotentially malicious service detected - " << lpServiceDetection->wsServiceName << L" (PID is " << lpServiceDetection->ServicePID << L")" << std::endl;
-					} else if(detection->DetectionType == DetectionType::Registry){
-						auto* lpRegistryDetection = reinterpret_cast<REGISTRY_DETECTION*>(detection);
+					} else if(detection->Type == DetectionType::Registry){
+						auto lpRegistryDetection = std::static_pointer_cast<REGISTRY_DETECTION>(detection);
 						std::wcout << L"\tPotentially malicious registry key detected - " << lpRegistryDetection->wsRegistryKeyPath << (lpRegistryDetection->wsRegistryKeyValue.length() ? L": " : L"") << lpRegistryDetection->wsRegistryKeyValue << std::endl;
 					} else {
 						std::wcout << L"\tUnknown detection type!" << std::endl;

--- a/BLUESPAWN-agent/Logging/src/DebugSink.cpp
+++ b/BLUESPAWN-agent/Logging/src/DebugSink.cpp
@@ -5,7 +5,8 @@
 #include "logging/DebugSink.h"
 
 namespace Log {
-	void DebugSink::LogMessage(const LogLevel& level, const std::string& message, const HuntInfo& info, const std::vector<DETECTION*>& detections){
+	void DebugSink::LogMessage(const LogLevel& level, const std::string& message, const HuntInfo& info, 
+		const std::vector<std::shared_ptr<DETECTION>>& detections){
 		if(level.Enabled()){
 			if(level.severity == Severity::LogHunt){
 				std::wstring aggressiveness = info.HuntAggressiveness == Aggressiveness::Aggressive ? L"Aggressive" :
@@ -14,17 +15,17 @@ namespace Log {
 				std::wstring sLogHeader = L"[" + info.HuntName + L": " + aggressiveness + L"] - ";
 				OutputDebugStringW((sLogHeader + std::to_wstring(detections.size()) + L" detection" + (detections.size() == 1 ? L"!" : L"s!")).c_str());
 				for(auto detection : detections){
-					if(detection->DetectionType == DetectionType::File){
-						auto* lpFileDetection = reinterpret_cast<FILE_DETECTION*>(detection);
+					if(detection->Type == DetectionType::File){
+						auto lpFileDetection = std::static_pointer_cast<FILE_DETECTION>(detection);
 						OutputDebugStringW((sLogHeader + L"\tPotentially malicious file detected - " + lpFileDetection->wsFileName).c_str());
-					} else if(detection->DetectionType == DetectionType::Process){
-						auto* lpProcessDetection = reinterpret_cast<PROCESS_DETECTION*>(detection);
+					} else if(detection->Type == DetectionType::Process){
+						auto lpProcessDetection = std::static_pointer_cast<PROCESS_DETECTION>(detection);
 						OutputDebugStringW((sLogHeader + L"\tPotentially malicious process detected - " + lpProcessDetection->wsImageName + L" (PID is " + std::to_wstring(lpProcessDetection->PID) + L")").c_str());
-					} else if(detection->DetectionType == DetectionType::Service){
-						auto* lpServiceDetection = reinterpret_cast<SERVICE_DETECTION*>(detection);
+					} else if(detection->Type == DetectionType::Service){
+						auto lpServiceDetection = std::static_pointer_cast<SERVICE_DETECTION>(detection);
 						OutputDebugStringW((sLogHeader + L"\tPotentially malicious service detected - " + lpServiceDetection->wsServiceName + L" (PID is " + std::to_wstring(lpServiceDetection->ServicePID) + L")").c_str());
-					} else if(detection->DetectionType == DetectionType::Registry){
-						auto* lpRegistryDetection = reinterpret_cast<REGISTRY_DETECTION*>(detection);
+					} else if(detection->Type == DetectionType::Registry){
+						auto lpRegistryDetection = std::static_pointer_cast<REGISTRY_DETECTION>(detection);
 						OutputDebugStringW((sLogHeader + L"\tPotentially malicious registry key detected - " + lpRegistryDetection->wsRegistryKeyPath + (lpRegistryDetection->wsRegistryKeyValue.length() ? L": " : L"") + lpRegistryDetection->wsRegistryKeyValue).c_str());
 					} else {
 						OutputDebugStringW((sLogHeader + L"\tUnknown detection type!").c_str());

--- a/BLUESPAWN-agent/Logging/src/HuntLogMessage.cpp
+++ b/BLUESPAWN-agent/Logging/src/HuntLogMessage.cpp
@@ -8,13 +8,15 @@ namespace Log {
 
 	HuntLogMessage::HuntLogMessage(const HuntInfo& Hunt, std::vector<std::reference_wrapper<LogSink>> sinks) :
 		LogMessage(sinks, LogLevel::LogHunt),
-		HuntName{ Hunt }{}
+		HuntName{ Hunt },
+		Detections{}{}
 
 	HuntLogMessage::HuntLogMessage(const HuntInfo& Hunt, const LogSink& sink) :
 		LogMessage(sink, LogLevel::LogHunt),
-		HuntName{ Hunt }{}
+		HuntName{ Hunt },
+		Detections{}{}
 
-	void HuntLogMessage::AddDetection(DETECTION* detection){
+	void HuntLogMessage::AddDetection(std::shared_ptr<DETECTION> detection){
 		this->Detections.emplace_back(detection);
 	}
 
@@ -26,9 +28,7 @@ namespace Log {
 			Sinks[idx].get().LogMessage(Level, message, HuntName, Detections);
 		}
 
-		for(auto Detection : Detections){
-			delete Detection;
-		}
+		Detections = {};
 
 		return *this;
 	}

--- a/BLUESPAWN-agent/Logging/src/Log.cpp
+++ b/BLUESPAWN-agent/Logging/src/Log.cpp
@@ -16,7 +16,7 @@ namespace Log {
 	LogMessage& LogMessage::operator<<(PCWSTR pointer){
 		return operator<<(std::wstring(pointer));
 	}
-	LogMessage& LogMessage::operator<<(const LogTerminator& terminator){		
+	LogMessage& LogMessage::operator<<(const LogTerminator& terminator){
 		std::string message = InternalStream.str();
 
 		InternalStream = std::stringstream();

--- a/BLUESPAWN-agent/Logging/src/ServerSink.cpp
+++ b/BLUESPAWN-agent/Logging/src/ServerSink.cpp
@@ -50,13 +50,13 @@ namespace Log {
 		return gpbInfo;
 	}
 
-	std::vector<gpb::FileReactionData> ServerSink::GetFileReactions(const std::vector<DETECTION*>& detections) {
+	std::vector<gpb::FileReactionData> ServerSink::GetFileReactions(const std::vector<std::shared_ptr<DETECTION>>& detections) {
 		std::vector<gpb::FileReactionData> fileDetections;
 
 		for (auto& detection : detections) {
 			// Extract all FILE_DETECTION objects
-			if (detection->DetectionType == DetectionType::File) {
-				FILE_DETECTION* fileDetection = (FILE_DETECTION*)detection;
+			if (detection->Type == DetectionType::File) {
+				auto fileDetection = std::static_pointer_cast<FILE_DETECTION>(detection);
 
 				gpb::FileReactionData gpbFileDetection;
 
@@ -67,56 +67,26 @@ namespace Log {
 		return fileDetections;
 	}
 
-	std::vector<gpb::RegistryReactionData> ServerSink::GetRegistryReactions(const std::vector<DETECTION*>& detections) {
+	std::vector<gpb::RegistryReactionData> ServerSink::GetRegistryReactions(const std::vector<std::shared_ptr<DETECTION>>& detections) {
 		return std::vector<gpb::RegistryReactionData>();
 	}
 
-	std::vector<gpb::ProcessReactionData> ServerSink::GetProcessReactions(const std::vector<DETECTION*>& detections) {
+	std::vector<gpb::ProcessReactionData> ServerSink::GetProcessReactions(const std::vector<std::shared_ptr<DETECTION>>& detections) {
 		return std::vector<gpb::ProcessReactionData>();
 	}
 
-	std::vector<gpb::ServiceReactionData> ServerSink::GetServiceReactions(const std::vector<DETECTION*>& detections) {
+	std::vector<gpb::ServiceReactionData> ServerSink::GetServiceReactions(const std::vector<std::shared_ptr<DETECTION>>& detections) {
 		return std::vector<gpb::ServiceReactionData>();
 	}
 
-	void ServerSink::LogMessage(const LogLevel& level, const std::string& message, const HuntInfo& info, const std::vector<DETECTION*>& detections){
+	void ServerSink::LogMessage(const LogLevel& level, const std::string& message, const HuntInfo& info, 
+		const std::vector<std::shared_ptr<DETECTION>>& detections){
 		if (!level.Enabled())
 			return;
 
-		gpb::HuntMessage huntMessage;
+		gpb::HuntMessage huntMessage{};
 		huntMessage.set_allocated_info(&HuntInfoToGPB(info));
 		huntMessage.set_extramessage(message);
-
-		if(level.severity == Severity::LogHunt){
-			std::wstring aggressiveness = info.HuntAggressiveness == Aggressiveness::Aggressive ? L"Aggressive" :
-				info.HuntAggressiveness == Aggressiveness::Careful ? L"Careful" :
-				info.HuntAggressiveness == Aggressiveness::Moderate ? L"Moderate" : L"Cursory";
-			std::wcout << L"[" << info.HuntName << L": " << aggressiveness << L"] ";
-			std::wcout << L" - " << detections.size() << " detection" << (detections.size() == 1 ? L"" : L"s") << L"!" << std::endl;
-			for(auto detection : detections){
-				if(detection->DetectionType == DetectionType::File){
-					auto* lpFileDetection = reinterpret_cast<FILE_DETECTION*>(detection); 
-					std::wcout << L"\tPotentially malicious file detected - " << lpFileDetection->wsFileName << L" (hash is " << lpFileDetection->hash << L")" << std::endl;
-				} else if(detection->DetectionType == DetectionType::Process){
-					auto* lpProcessDetection = reinterpret_cast<PROCESS_DETECTION*>(detection);
-					std::wcout << L"\tPotentially malicious process detected - " << lpProcessDetection->wsImageName << L" (PID is " << lpProcessDetection->PID << L")" << std::endl;
-				} else if(detection->DetectionType == DetectionType::Service){
-					auto* lpServiceDetection = reinterpret_cast<SERVICE_DETECTION*>(detection);
-					std::wcout << L"\tPotentially malicious service detected - " << lpServiceDetection->wsServiceName << L" (PID is " << lpServiceDetection->ServicePID << L")" << std::endl;
-				} else if(detection->DetectionType == DetectionType::Registry){
-					auto* lpRegistryDetection = reinterpret_cast<REGISTRY_DETECTION*>(detection);
-					std::wcout << L"\tPotentially malicious registry key detected - " << lpRegistryDetection->wsRegistryKeyPath << (lpRegistryDetection->wsRegistryKeyValue.length() ? L": " : L"") << lpRegistryDetection->wsRegistryKeyValue << std::endl;
-				} else {
-					std::wcout << L"\tUnknown detection type!" << std::endl;
-				}
-			}
-			if(message.size() > 0){
-				std::cout << "\tAssociated Message: " << message << std::endl;
-			}
-		} else {
-			std::cout << ServerSink::MessagePrepends[static_cast<WORD>(level.severity)] << " ";
-			std::cout << message << std::endl;
-		}
 	}
 
 	bool ServerSink::operator==(const LogSink& sink) const {

--- a/BLUESPAWN-agent/Project Configurations/buildsettings.props
+++ b/BLUESPAWN-agent/Project Configurations/buildsettings.props
@@ -14,6 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level1</WarningLevel>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <PreprocessorDefinitions>_UNICODE;UNICODE;_ITERATOR_DEBUG_LEVEL=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/BLUESPAWN-agent/React/Reactions/headers/reactions/Detections.h
+++ b/BLUESPAWN-agent/React/Reactions/headers/reactions/Detections.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <functional>
+#include <memory>
 
 #include "hunts/HuntInfo.h"
 
@@ -15,55 +16,80 @@ enum class DetectionType {
 };
 
 struct DETECTION {
-	DetectionType DetectionType;
+	DetectionType Type;
+	DETECTION(DetectionType Type) : Type{ Type }{}
 };
 
 /// A struct containing information about a file identified in a hunt
-struct FILE_DETECTION {
-	DetectionType DetectionType;
+/// Note that the hash will have to be manually set.
+struct FILE_DETECTION : public DETECTION {
 	std::wstring wsFileName;
 	BYTE hash[256];
+	FILE_DETECTION(const std::wstring& wsFileName) : 
+		DETECTION{ DetectionType::File },
+		wsFileName{ wsFileName },
+		hash{}{}
 };
-typedef std::function<void(FILE_DETECTION*)> DetectFile;
+typedef std::function<void(std::shared_ptr<FILE_DETECTION>)> DetectFile;
 
 /// A struct containing information about a registry key value identified in a hunt
-struct REGISTRY_DETECTION {
-	DetectionType DetectionType;
+struct REGISTRY_DETECTION : public DETECTION {
 	std::wstring wsRegistryKeyPath;
 	std::wstring wsRegistryKeyValue;
 	BYTE* contents;
+	REGISTRY_DETECTION(const std::wstring& wsRegistryKeyPath, const std::wstring& wsRegistryKeyValue, BYTE* contents) :
+		DETECTION{ DetectionType::Registry },
+		wsRegistryKeyPath{ wsRegistryKeyPath },
+		wsRegistryKeyValue{ wsRegistryKeyValue },
+		contents{ contents }{}
 };
-typedef std::function<void(REGISTRY_DETECTION*)> DetectRegistry;
+typedef std::function<void(std::shared_ptr<REGISTRY_DETECTION>)> DetectRegistry;
 
 /// A struct containing information about a service identified in a hunt
-struct SERVICE_DETECTION {
-	DetectionType DetectionType;
+struct SERVICE_DETECTION : public DETECTION {
 	std::wstring wsServiceName;
 	std::wstring wsServiceExecutablePath;
 	std::wstring wsServiceDll;
 	int ServicePID;
+	SERVICE_DETECTION(const std::wstring& wsServiceName, const std::wstring& wsServiceExecutablePath, 
+		const std::wstring& wsServiceDll, const int& ServicePID) :
+		DETECTION{ DetectionType::Service },
+		wsServiceName{ wsServiceName },
+		wsServiceExecutablePath{ wsServiceExecutablePath },
+		wsServiceDll{ wsServiceDll },
+		ServicePID{ ServicePID }{}
 };
-typedef std::function<void(SERVICE_DETECTION*)> DetectService;
+typedef std::function<void(std::shared_ptr<SERVICE_DETECTION>)> DetectService;
 
 enum ProcessDetectionMethod {
 	NotImageBacked,
 	BackingImageMismatch,
 	NotInLoader,
-	NotSigned
+	NotSigned,
+	Other
 };
 
 /// A struct containing information about a process identified in a hunt
-struct PROCESS_DETECTION {
-	DetectionType DetectionType;
+/// Note that the AllocationStart must be filled in manually
+struct PROCESS_DETECTION : public DETECTION {
 	std::wstring wsImageName;
 	std::wstring wsImagePath;
 	std::wstring wsCmdline;
 	int PID;
 	int TID;
 	ProcessDetectionMethod method;
-	BYTE AllocationStart[512];
+	BYTE AllocationStart[512];      // This member is intended to be used for signaturing purposes
+	PROCESS_DETECTION(const std::wstring& wsImageName, const std::wstring& wsImagePath, const std::wstring& wsCmdLine,
+		const int& PID, const int& TID, ProcessDetectionMethod method) :
+		DETECTION{ DetectionType::Process },
+		wsImageName{ wsImageName },
+		wsImagePath{ wsCmdLine },
+		PID{ PID },
+		TID{ TID },
+		method{ method },
+		AllocationStart{}{}
 };
-typedef std::function<void(PROCESS_DETECTION*)> DetectProcess;
+typedef std::function<void(std::shared_ptr<PROCESS_DETECTION>)> DetectProcess;
 
 typedef std::function<void(const HuntInfo&)> HuntStart;
 typedef std::function<void()> HuntEnd;

--- a/BLUESPAWN-agent/React/Reactions/headers/reactions/Log.h
+++ b/BLUESPAWN-agent/React/Reactions/headers/reactions/Log.h
@@ -12,14 +12,14 @@ namespace Reactions {
 		Log::HuntLogMessage _HuntLogMessage;
 		bool HuntBegun = false;
 
-		void BeginHunt(const HuntInfo& info);
-		void EndHunt();
+		void LogBeginHunt(const HuntInfo& info);
+		void LogEndHunt();
 
 		/// Handlers for detections that log the detection
-		void FileIdentified(FILE_DETECTION* detection);
-		void RegistryKeyIdentified(REGISTRY_DETECTION* detection);
-		void ProcessIdentified(PROCESS_DETECTION* detection);
-		void ServiceIdentified(SERVICE_DETECTION* detection);
+		void LogFileIdentified(std::shared_ptr<FILE_DETECTION> detection);
+		void LogRegistryKeyIdentified(std::shared_ptr<REGISTRY_DETECTION> detection);
+		void LogProcessIdentified(std::shared_ptr<PROCESS_DETECTION> detection);
+		void LogServiceIdentified(std::shared_ptr<SERVICE_DETECTION> detection);
 
 	public:
 		LogReaction();

--- a/BLUESPAWN-agent/React/Reactions/headers/reactions/Reaction.h
+++ b/BLUESPAWN-agent/React/Reactions/headers/reactions/Reaction.h
@@ -28,14 +28,14 @@ protected:
 
 public: 
 	/// These functions handle the beginning and end of hunts
-	void BeginHunt(const HuntInfo& info) const;
-	void EndHunt() const;
+	void BeginHunt(const HuntInfo& info);
+	void EndHunt();
 
 	/// These functions handle the identification of a detection by calling all of the associated handlers
-	void FileIdentified(FILE_DETECTION*) const;
-	void RegistryKeyIdentified(REGISTRY_DETECTION*) const;
-	void ProcessIdentified(PROCESS_DETECTION*) const;
-	void ServiceIdentified(SERVICE_DETECTION*) const;
+	void FileIdentified(std::shared_ptr<FILE_DETECTION>);
+	void RegistryKeyIdentified(std::shared_ptr<REGISTRY_DETECTION>);
+	void ProcessIdentified(std::shared_ptr<PROCESS_DETECTION>);
+	void ServiceIdentified(std::shared_ptr<SERVICE_DETECTION>);
 
 	/// These functions add handlers for beginning and ending hunts
 	void AddHuntBegin(HuntStart handler);

--- a/BLUESPAWN-agent/React/Reactions/src/Log.cpp
+++ b/BLUESPAWN-agent/React/Reactions/src/Log.cpp
@@ -6,37 +6,37 @@
 #include "logging/HuntLogMessage.h"
 
 namespace Reactions {
-	void LogReaction::BeginHunt(const HuntInfo& info){
+	void LogReaction::LogBeginHunt(const HuntInfo& info){
 		_HuntLogMessage = { info, Log::_LogHuntSinks };
 		HuntBegun = true;
 	}
-	void LogReaction::EndHunt(){
+	void LogReaction::LogEndHunt(){
 		_HuntLogMessage << Log::endlog;
 		_HuntLogMessage = { HuntInfo{}, std::vector<std::reference_wrapper<Log::LogSink>>{} };
 		HuntBegun = false;
 	}
-	void LogReaction::FileIdentified(FILE_DETECTION* detection){
+	void LogReaction::LogFileIdentified(std::shared_ptr<FILE_DETECTION> detection){
 		if(HuntBegun){
 			LOG_HUNT_DETECTION(detection);
 		} else {
 			LOG_ERROR("Potentially malicious file " << detection->wsFileName << " detected outside of a hunt!");
 		}
 	}
-	void LogReaction::RegistryKeyIdentified(REGISTRY_DETECTION* detection){
+	void LogReaction::LogRegistryKeyIdentified(std::shared_ptr<REGISTRY_DETECTION> detection){
 		if(HuntBegun){
 			LOG_HUNT_DETECTION(detection);
 		} else {
 			LOG_ERROR("Potentially malicious registry key " << detection->wsRegistryKeyPath << (detection->wsRegistryKeyValue.length() ? L": " : L"") << detection->wsRegistryKeyValue << " detected outside of a hunt!");
 		}
 	}
-	void LogReaction::ProcessIdentified(PROCESS_DETECTION* detection){
+	void LogReaction::LogProcessIdentified(std::shared_ptr<PROCESS_DETECTION> detection){
 		if(HuntBegun){
 			LOG_HUNT_DETECTION(detection);
 		} else {
 			LOG_ERROR("Potentially malicious process " << detection->wsImageName << " (PID " << detection->PID << ") detected outside of a hunt!");
 		}
 	}
-	void LogReaction::ServiceIdentified(SERVICE_DETECTION* detection){
+	void LogReaction::LogServiceIdentified(std::shared_ptr<SERVICE_DETECTION> detection){
 		if(HuntBegun){
 			LOG_HUNT_DETECTION(detection);
 		} else {
@@ -46,11 +46,11 @@ namespace Reactions {
 
 	LogReaction::LogReaction() : 
 		_HuntLogMessage{ HuntInfo{}, std::vector<std::reference_wrapper<Log::LogSink>>{} }{
-		vStartHuntProcs.emplace_back(std::bind(&LogReaction::BeginHunt, this, std::placeholders::_1));
-		vEndHuntProcs.emplace_back(std::bind(&LogReaction::EndHunt, this));
-		vRegistryReactions.emplace_back(std::bind(&LogReaction::RegistryKeyIdentified, this, std::placeholders::_1));
-		vFileReactions.emplace_back(std::bind(&LogReaction::FileIdentified, this, std::placeholders::_1));
-		vProcessReactions.emplace_back(std::bind(&LogReaction::ProcessIdentified, this, std::placeholders::_1));
-		vServiceReactions.emplace_back(std::bind(&LogReaction::ServiceIdentified, this, std::placeholders::_1));
+		vStartHuntProcs.emplace_back(std::bind(&LogReaction::LogBeginHunt, this, std::placeholders::_1));
+		vEndHuntProcs.emplace_back(std::bind(&LogReaction::LogEndHunt, this));
+		vRegistryReactions.emplace_back(std::bind(&LogReaction::LogRegistryKeyIdentified, this, std::placeholders::_1));
+		vFileReactions.emplace_back(std::bind(&LogReaction::LogFileIdentified, this, std::placeholders::_1));
+		vProcessReactions.emplace_back(std::bind(&LogReaction::LogProcessIdentified, this, std::placeholders::_1));
+		vServiceReactions.emplace_back(std::bind(&LogReaction::LogServiceIdentified, this, std::placeholders::_1));
 	}
 }

--- a/BLUESPAWN-agent/React/Reactions/src/Reaction.cpp
+++ b/BLUESPAWN-agent/React/Reactions/src/Reaction.cpp
@@ -1,32 +1,32 @@
 #include "reactions/Reaction.h"
 
-void Reaction::BeginHunt(const HuntInfo& info) const {
+void Reaction::BeginHunt(const HuntInfo& info){
 	for(auto BeginProc : vStartHuntProcs){
 		BeginProc(info);
 	}
 }
-void Reaction::EndHunt() const {
+void Reaction::EndHunt(){
 	for(auto EndProc : vEndHuntProcs){
 		EndProc();
 	}
 }
 
-void Reaction::FileIdentified(FILE_DETECTION* info) const {
+void Reaction::FileIdentified(std::shared_ptr<FILE_DETECTION> info){
 	for(auto reaction : vFileReactions){
 		reaction(info);
 	}
 }
-void Reaction::RegistryKeyIdentified(REGISTRY_DETECTION* info) const {
+void Reaction::RegistryKeyIdentified(std::shared_ptr<REGISTRY_DETECTION> info){
 	for(auto reaction : vRegistryReactions){
 		reaction(info);
 	}
 }
-void Reaction::ProcessIdentified(PROCESS_DETECTION* info) const {
+void Reaction::ProcessIdentified(std::shared_ptr<PROCESS_DETECTION> info){
 	for(auto reaction : vProcessReactions){
 		reaction(info);
 	}
 }
-void Reaction::ServiceIdentified(SERVICE_DETECTION* info) const {
+void Reaction::ServiceIdentified(std::shared_ptr<SERVICE_DETECTION> info){
 	for(auto reaction : vServiceReactions){
 		reaction(info);
 	}


### PR DESCRIPTION
This branch fixes several bugs including

 * Possible use-after-free when combining reactions with logging
 * Null-pointer dereference when running in debug mode
 * Registry key values not being recorded when enumerating values of a registry key.
