### PR TITLE
Fix incorrect log levels not handled correctly

### DIFF
--- a/BLUESPAWN-agent/BLUESPAWN/src/BLUESPAWN.cpp
+++ b/BLUESPAWN-agent/BLUESPAWN/src/BLUESPAWN.cpp
@@ -77,8 +77,13 @@ void dispatch_hunt(cxxopts::ParseResult result, cxxopts::Options options) {
 	else if (sHuntLevelFlag == "Careful") {
 		aHuntLevel = Aggressiveness::Careful;
 	}
-	else {
+	else if (sHuntLevelFlag == "Aggressive") {
 		aHuntLevel = Aggressiveness::Aggressive;
+	}
+	else {
+		std::cerr << "Error " << sHuntLevelFlag << " - Unknown hunt level. Please specify either Cursory, Moderate, Careful, or Aggressive" << std::endl;
+		std::cerr << "Will default to Moderate for this run." << std::endl;
+		aHuntLevel = Aggressiveness::Moderate;
 	}
 
 	HuntRegister record{};

--- a/BLUESPAWN-agent/Hunt/FileSystem/headers/filesystem/FileSystem.h
+++ b/BLUESPAWN-agent/Hunt/FileSystem/headers/filesystem/FileSystem.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
+
 #include <stdio.h>
 #include <windows.h>
 #include <Wincrypt.h>

--- a/BLUESPAWN-agent/Hunt/FileSystem/headers/filesystem/FileSystem.h
+++ b/BLUESPAWN-agent/Hunt/FileSystem/headers/filesystem/FileSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
+#include <experimental/filesystem>
 
 #include <stdio.h>
 #include <windows.h>


### PR DESCRIPTION
When an unknown log level is provided, show an error message and set the default log level to 'Moderate'.

