### PR TITLE
Fix a memory leak

### DIFF
--- a/BLUESPAWN-client/BLUESPAWN-client.vcxproj.user
+++ b/BLUESPAWN-client/BLUESPAWN-client.vcxproj.user
@@ -1,13 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LocalDebuggerCommandArguments>
-    </LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>--hunt -l Cursory</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>
-    </LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>--hunt -l Cursory</LocalDebuggerCommandArguments>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LocalDebuggerCommandArguments>--hunt -l Cursory</LocalDebuggerCommandArguments>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LocalDebuggerCommandArguments>--hunt -l Cursory</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
 </Project>

--- a/BLUESPAWN-client/BLUESPAWN-client.vcxproj.user
+++ b/BLUESPAWN-client/BLUESPAWN-client.vcxproj.user
@@ -1,19 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LocalDebuggerCommandArguments>--hunt -l Cursory</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>--hunt -l Cursory</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LocalDebuggerCommandArguments>--hunt -l Cursory</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <LocalDebuggerCommandArguments>--hunt -l Cursory</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
 </Project>

--- a/BLUESPAWN-client/headers/hunt/RegistryHunt.h
+++ b/BLUESPAWN-client/headers/hunt/RegistryHunt.h
@@ -19,7 +19,7 @@ namespace Registry {
 
 	typedef std::function<bool(const std::wstring&, const std::wstring&)> REG_SZ_CHECK;
 	typedef std::function<bool(DWORD, DWORD)> REG_DWORD_CHECK;
-	typedef std::function<bool(LPVOID, LPVOID)> REG_BINARY_CHECK;
+	typedef std::function<bool(AllocationWrapper, AllocationWrapper)> REG_BINARY_CHECK;
 	typedef std::function<bool(const std::vector<std::wstring>&, const std::vector<std::wstring>&)> REG_MULTI_SZ_CHECK;
 
 	extern REG_SZ_CHECK CheckSzEqual;
@@ -55,15 +55,10 @@ namespace Registry {
 			REG_SZ_CHECK check = CheckSzEqual);
 		RegistryCheck(std::wstring wValueName, RegistryType type, DWORD dwData, bool MissingBad = false,
 			REG_DWORD_CHECK check = CheckDwordEqual);
-		RegistryCheck(std::wstring wValueName, RegistryType type, MemoryWrapper<> lpData, bool MissingBad = false,
+		RegistryCheck(std::wstring wValueName, RegistryType type, AllocationWrapper lpData, bool MissingBad = false,
 			REG_BINARY_CHECK check = CheckBinaryEqual);
 		RegistryCheck(std::wstring wValueName, RegistryType type, std::vector<std::wstring> wData, bool MissingBad = false,
 			REG_MULTI_SZ_CHECK check = CheckMultiSzSubset);
-
-		RegistryCheck(const RegistryCheck& copy);
-		RegistryCheck operator=(const RegistryCheck& copy);
-
-		~RegistryCheck();
 
 		RegistryType GetType() const;
 	};

--- a/BLUESPAWN-client/headers/util/configurations/Registry.h
+++ b/BLUESPAWN-client/headers/util/configurations/Registry.h
@@ -106,10 +106,10 @@ namespace Registry {
 		/**
 		 * Reads the raw bytes present in a given value. 
 		 *
-		 * @return A MemoryWrapper object pointing to the bytes read if the value is present, or
+		 * @return A AllocationWrapper object pointing to the bytes read if the value is present, or
 		 *	       an empty memory wrapper if the value is not present. The memory must be freed.
 		 */
-		MemoryWrapper<BYTE> GetRawValue(std::wstring wsValueName) const;
+		AllocationWrapper GetRawValue(std::wstring wsValueName) const;
 
 		/**
 		 * Writes bytes to a given value under the key referenced by this object.
@@ -120,7 +120,7 @@ namespace Registry {
 		 *
 		 * @return True if the value was successfully set; false otherwise
 		 */
-		bool SetRawValue(std::wstring name, MemoryWrapper<BYTE> bytes, DWORD type = REG_BINARY) const;
+		bool SetRawValue(std::wstring name, AllocationWrapper bytes, DWORD type = REG_BINARY) const;
 
 		/**
 		 * Reads data from the specified value and handles conversion to common types.

--- a/BLUESPAWN-client/headers/util/configurations/RegistryValue.h
+++ b/BLUESPAWN-client/headers/util/configurations/RegistryValue.h
@@ -32,12 +32,12 @@ namespace Registry {
 		// Only one of these will be valid data; which one will be indicated by `type`
 		std::wstring wData = {};
 		DWORD dwData = {};
-		MemoryWrapper<> lpData = { nullptr, 0 };
+		AllocationWrapper lpData = { nullptr, 0 };
 		std::vector<std::wstring> vData = {};
 
 		RegistryValue(std::wstring wValueName, RegistryType type, std::wstring wData);
 		RegistryValue(std::wstring wValueName, RegistryType type, DWORD dwData);
-		RegistryValue(std::wstring wValueName, RegistryType type, MemoryWrapper<> lpData);
+		RegistryValue(std::wstring wValueName, RegistryType type, AllocationWrapper lpData);
 		RegistryValue(std::wstring wValueName, RegistryType type, std::vector<std::wstring> wData);
 
 		RegistryType GetType() const;

--- a/BLUESPAWN-client/src/hunt/hunts/HuntT1004.cpp
+++ b/BLUESPAWN-client/src/hunt/hunts/HuntT1004.cpp
@@ -31,7 +31,7 @@ namespace Hunts {
 		auto HKLMWinlogonWoW64 = RegistryKey{ HKEY_LOCAL_MACHINE, L"Software\\Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon" };
 		keys.emplace(HKLMWinlogonWoW64, CheckValues(HKLMWinlogonWoW64, {
 			{ L"Shell", RegistryType::REG_SZ_T, L"explorer\\.exe,?", true, CheckSzRegexMatch },
-			{ L"UserInit", RegistryType::REG_SZ_T, L"((U|u)(SERINIT|serinit)\\.(exe|EXE),?)?", false, CheckSzRegexMatch }
+			{ L"UserInit", RegistryType::REG_SZ_T, L"C:\\\\(Windows|WINDOWS|windows)\\\\(System32|SYSTEM32|system32)\\\\(U|u)(SERINIT|serinit)\\.(exe|EXE),?", false, CheckSzRegexMatch }
 		}));
 
 		auto HKCUWinlogon = RegistryKey{ HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon" };

--- a/BLUESPAWN-client/src/util/configurations/RegistryValue.cpp
+++ b/BLUESPAWN-client/src/util/configurations/RegistryValue.cpp
@@ -12,7 +12,7 @@ namespace Registry {
 		type{ type },
 		dwData{ dwData }{}
 
-	RegistryValue::RegistryValue(std::wstring wValueName, RegistryType type, MemoryWrapper<> lpData) :
+	RegistryValue::RegistryValue(std::wstring wValueName, RegistryType type, AllocationWrapper lpData) :
 		wValueName{ wValueName },
 		type{ type },
 		lpData{ lpData }{}
@@ -38,14 +38,14 @@ namespace Registry {
 			}
 			return string.substr(0, string.length() - 3) + L"\"]";
 		} else {
-			if(!lpData.address){
+			if(!lpData){
 				return L"(null)";
 			}
 
 			std::wstring string = L"";
-			for(auto* byte = lpData.address; byte < lpData.address + lpData.MemorySize; byte++){
+			for(auto i = 0; i < lpData.GetSize(); i++){
 				wchar_t buf[3];
-				wsprintf(buf, L"%02x", *byte);
+				wsprintf(buf, L"%02x", lpData[i]);
 				string += buf;
 				string += L" ";
 			}


### PR DESCRIPTION
Switch memory wrapping framework to use smart pointers and automatically free data to fix a memory leak caused by the reaction framework not properly handling binary registry keys