### PR TITLE
Obfuscate yara rules to avoid AV false positives

### DIFF
--- a/BLUESPAWN-win-client/src/hunt/hunts/HuntT1068.cpp
+++ b/BLUESPAWN-win-client/src/hunt/hunts/HuntT1068.cpp
@@ -2,6 +2,7 @@
 
 #include <regex>
 
+#include "hunt/Scope.h"
 #include "util/configurations/Registry.h"
 #include "util/filesystem/FileSystem.h"
 #include "util/log/Log.h"
@@ -27,7 +28,7 @@ namespace Hunts {
         SUBSECTION_INIT(PRINTERS, Cursory)
         RegistryKey printers{ HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Print\\Printers",
                               true };
-        for(auto printer : printers.EnumerateSubkeys()) {
+        for(auto& printer : printers.EnumerateSubkeys()) {
             if(printer.ValueExists(L"Port")) {
                 auto value{ RegistryValue::Create(printer, L"Port") };
                 FileSystem::File filepath{ value->ToString() };
@@ -44,7 +45,7 @@ namespace Hunts {
 
         SUBSECTION_INIT(PORTS, Cursory);
         RegistryKey ports{ HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Ports", true };
-        for(auto value : ports.EnumerateValues()) {
+        for(auto& value : ports.EnumerateValues()) {
             FileSystem::File filepath{ value };
 
             // Regex ensures the file is an actual drive and not, say, a COM port

--- a/BLUESPAWN-win-client/src/util/eventlogs/EventLogs.cpp
+++ b/BLUESPAWN-win-client/src/util/eventlogs/EventLogs.cpp
@@ -224,7 +224,7 @@ namespace EventLogs {
 
         // Open the channel config
         EventWrapper hChannel{ EvtOpenChannelConfig(NULL, channel.c_str(), 0) };
-        if(NULL == hChannel) {
+        if(!hChannel) {
             LOG_ERROR(L"EventLogs::IsChannelOpen: EvtOpenChannelConfig failed with " + std::to_wstring(GetLastError()) +
                       L" for channel " + channel);
             return false;


### PR DESCRIPTION
Obfuscate yara rules pre-zipping with a rolling XOR (and a bit of other stuff in there) to avoid AV false positives. Also fix an issue with an EventWrapper being compared to NULL.