### PR TITLE
Small Compiler fix

### DIFF
--- a/BLUESPAWN-win-client/src/user/BLUESPAWN.cpp
+++ b/BLUESPAWN-win-client/src/user/BLUESPAWN.cpp
@@ -538,9 +538,9 @@ int main(int argc, char* argv[]) {
         }
 
         bluespawn.Run();
-    } catch(cxxopts::OptionParseException e1) {
+    } catch(const std::exception& e) {
         Bluespawn::io.InformUser(StringToWidestring(options.help()));
-        LOG_ERROR(e1.what());
+        LOG_ERROR(e.what());
     }
     return 0;
 }

--- a/BLUESPAWN-win-client/src/util/eventlogs/EventLogs.cpp
+++ b/BLUESPAWN-win-client/src/util/eventlogs/EventLogs.cpp
@@ -224,7 +224,7 @@ namespace EventLogs {
 
         // Open the channel config
         EventWrapper hChannel{ EvtOpenChannelConfig(NULL, channel.c_str(), 0) };
-        if(NULL == hChannel) {
+        if(reinterpret_cast<HANDLE>(NULL) == hChannel) {
             LOG_ERROR(L"EventLogs::IsChannelOpen: EvtOpenChannelConfig failed with " + std::to_wstring(GetLastError()) +
                       L" for channel " + channel);
             return false;


### PR DESCRIPTION
Bluespawn.cpp changes:
catch(const std::exception& e) {
        Bluespawn::io.InformUser(StringToWidestring(options.help()));
        LOG_ERROR(e.what());
Eventlog.cpp changes:
 // Open the channel config
        EventWrapper hChannel{ EvtOpenChannelConfig(NULL, channel.c_str(), 0) };
        if(reinterpret_cast<HANDLE>(NULL) == hChannel) {
            LOG_ERROR(L"EventLogs::IsChannelOpen: EvtOpenChannelConfig failed with " + std::to_wstring(GetLastError()) +
                      L" for channel " + channel);
            return false;
        }